### PR TITLE
Two fixes for latest docker release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,11 @@
 .git
 .DS_Store
-data/.DS_Store
-data/*
 *.Rproj
 *.Rproj.user
 .Rhistory
 .RData
 rsconnect/
+data/.DS_Store
 data/fenton_data.zip
 data/fenton.csr
 data/groeicurve_b.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
 # R packages (pinned to a Posit Package Manager snapshot for reproducibility)
 RUN R -e 'install.packages(c(\
               "shiny", \
+              "shinythemes", \
               "tidyverse", \
               "readxl", \
               "bslib", \
@@ -23,7 +24,7 @@ RUN R -e 'install.packages(c(\
               "plotly", \
               "DT" \
             ), \
-            repos="https://packagemanager.posit.co/cran/__linux__/jammy/2024-12-01"\
+            repos="https://packagemanager.posit.co/cran/__linux__/noble/2024-12-01"\
           )'
 
 # copy app (www/, data/, app.R, …); see .dockerignore for exclusions


### PR DESCRIPTION
@rmvpaeme ,

- De rocker 4.4.2 image steunt op Ubuntu 24.04 en ik kreeg fouten omdat de packages nog van jammy (22.04) genomen werden.
- De data dit volledig excluderen lijkt me niet de bedoeling in docker?
